### PR TITLE
fix/Link browse-button to /docs/components/button

### DIFF
--- a/components/ui/browse-button.tsx
+++ b/components/ui/browse-button.tsx
@@ -35,7 +35,7 @@ export function BrowseComponentsButton() {
     };
 
     return (
-        <Link href="/docs" className="block">
+        <Link href="/docs/components/button" className="block">
             <div
                 className="relative inline-flex items-center gap-2 px-6 py-3 
                     bg-zinc-900 dark:bg-zinc-100 


### PR DESCRIPTION
`Browse Components` button on the landing page hero section was linking to `/docs`. Fixed to link it to `/docs/components/button` to be consistent with the navbar's `Components` button.