### PR TITLE
fix: added .com in pnpm utilities command

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -21,7 +21,7 @@ npx shadcn@latest add https://kokonutui.com/r/utils.json
 ```
 
 ```bash tab="pnpm"
-pnpm dlx shadcn@latest add https://kokonutui/r/utils.json
+pnpm dlx shadcn@latest add https://kokonutui.com/r/utils.json
 ```
 
 </Tabs>


### PR DESCRIPTION
Added missing .com to the `pnpm dlx shadcn@latest`  command for installing utilities

Before:
`pnpm dlx shadcn@latest add https://kokonutui/r/utils.json`
After:
`pnpm dlx shadcn@latest add https://kokonutui.com/r/utils.json`