### PR TITLE
a11y(mouse-effect-card): add keyboard navigation and focus support

### DIFF
--- a/components/kokonutui/mouse-effect-card.tsx
+++ b/components/kokonutui/mouse-effect-card.tsx
@@ -296,6 +296,18 @@ export default function MouseEffectCard({
     mouseY.set(Number.POSITIVE_INFINITY);
   };
 
+  const handleFocus = () => {
+    if (!innerContainerRef.current) return;
+    const rect = innerContainerRef.current.getBoundingClientRect();
+    mouseX.set(rect.width / 2);
+    mouseY.set(rect.height / 2);
+  };
+
+  const handleBlur = () => {
+    mouseX.set(Number.POSITIVE_INFINITY);
+    mouseY.set(Number.POSITIVE_INFINITY);
+  };
+
   return (
     <Card
       className={cn(
@@ -306,9 +318,12 @@ export default function MouseEffectCard({
       <CardContent
         aria-label={ariaLabel ?? `${title} — ${subtitle}`}
         className="relative h-[400px] w-full overflow-hidden p-0"
+        onBlur={handleBlur}
+        onFocus={handleFocus}
         onMouseLeave={handleMouseLeave}
         onMouseMove={handleMouseMove}
         ref={innerContainerRef}
+        tabIndex={0}
       >
         {dots.map((dot, index) => (
           <DotComponent

--- a/components/kokonutui/mouse-effect-card.tsx
+++ b/components/kokonutui/mouse-effect-card.tsx
@@ -44,6 +44,7 @@ export interface MouseEffectCardProps {
   secondaryCtaText?: string;
   secondaryCtaUrl?: string;
   footerText?: string;
+  ariaLabel?: string;
 }
 
 interface Dot {
@@ -252,6 +253,7 @@ export default function MouseEffectCard({
   secondaryCtaText = "View Docs",
   secondaryCtaUrl = "#",
   footerText = "We do it all",
+  ariaLabel,
 }: MouseEffectCardProps) {
   const innerContainerRef = useRef<HTMLDivElement>(null);
   const mouseX = useMotionValue(Number.POSITIVE_INFINITY);
@@ -302,6 +304,7 @@ export default function MouseEffectCard({
       )}
     >
       <CardContent
+        aria-label={ariaLabel ?? `${title} — ${subtitle}`}
         className="relative h-[400px] w-full overflow-hidden p-0"
         onMouseLeave={handleMouseLeave}
         onMouseMove={handleMouseMove}

--- a/components/kokonutui/mouse-effect-card.tsx
+++ b/components/kokonutui/mouse-effect-card.tsx
@@ -308,6 +308,41 @@ export default function MouseEffectCard({
     mouseY.set(Number.POSITIVE_INFINITY);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!innerContainerRef.current) return;
+    const rect = innerContainerRef.current.getBoundingClientRect();
+    const step = Math.min(rect.width, rect.height) * 0.2;
+    const currentX = Number.isFinite(mouseX.get())
+      ? mouseX.get()
+      : rect.width / 2;
+    const currentY = Number.isFinite(mouseY.get())
+      ? mouseY.get()
+      : rect.height / 2;
+
+    switch (e.key) {
+      case "ArrowUp":
+        e.preventDefault();
+        mouseY.set(Math.max(0, currentY - step));
+        mouseX.set(currentX);
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        mouseY.set(Math.min(rect.height, currentY + step));
+        mouseX.set(currentX);
+        break;
+      case "ArrowLeft":
+        e.preventDefault();
+        mouseX.set(Math.max(0, currentX - step));
+        mouseY.set(currentY);
+        break;
+      case "ArrowRight":
+        e.preventDefault();
+        mouseX.set(Math.min(rect.width, currentX + step));
+        mouseY.set(currentY);
+        break;
+    }
+  };
+
   return (
     <Card
       className={cn(
@@ -320,6 +355,7 @@ export default function MouseEffectCard({
         className="relative h-[400px] w-full overflow-hidden p-0"
         onBlur={handleBlur}
         onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
         onMouseLeave={handleMouseLeave}
         onMouseMove={handleMouseMove}
         ref={innerContainerRef}


### PR DESCRIPTION
## Summary

### Motivation                                                                                                                                   
                                                                                                                                               
The mouse-effect-card component relies entirely on mouse interaction to display its dot effect, making it inaccessible to keyboard-only users and screen readers. 
So, this PR adds accessibility support so that all users can interact with the component.                                   
                                                                                                                                               
### What I have done                                                                                                                             
                                                                                                                                               
  1. Add aria-label to CardContent for screen reader support (f9df07c)                                                                         
    - Introduced an ariaLabel prop with a fallback to title/subtitle, ensuring screen readers can announce the card's content.                 
  2. Add focus/blur handlers with tabIndex (c14b150)                                                                                           
    - Made CardContent focusable via tabIndex={0}.                                                                                             
    - On focus, the dot effect appears at the center of the card; on blur, it resets.                                                          
  3. Add arrow key navigation for the dot effect (87db0aa)                                                                                     
    - Arrow keys move the dot effect position as a keyboard alternative to mouse movement, with step size relative to the container.           
                                                                                                                                               
### Test Plan 
- Verify the card is focusable via the Tab key 
- Verify the dot effect appears at center on focus and disappears on blur
- Verify arrow keys move the dot effect within the card
- Verify the aria-label is announced correctly by a screen reader (e.g., VoiceOver) 